### PR TITLE
chore: add useCloudFormation in all serverless.ts

### DIFF
--- a/packages/serverless-configuration/sharedConfig.ts
+++ b/packages/serverless-configuration/sharedConfig.ts
@@ -17,6 +17,9 @@ export const sharedProviderConfig = {
     AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
     NODE_OPTIONS: '--enable-source-maps --stack-trace-limit=1000',
   },
+  eventBridge: {
+    useCloudFormation: true,
+  },
 } as const;
 
 export const sharedEnvsConfig = {


### PR DESCRIPTION
I think it would be a good idea to add the flag `useCloudFormation` by default.
It is very easy to forget to add it when using event bridge which will lead to : 

- painful bug if we try to add it afterwards
- the use of a legacy way to provision event rule and lambda triggers with event bridge