### PR TITLE
fix: use postinstall instead of prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "graph": "nx dep-graph",
     "info": "nx run-many --target=sls:info --all --parallel=4",
     "package": "nx run-many --target=package --all --parallel=4",
-    "prepare": "husky install && syncpack format",
+    "postinstall": "husky install && syncpack format",
     "resolve-audit": "resolve-audit --yarn",
     "test:affected": "nx affected --target=test:all",
     "test:all": "nx run-many --target=test:all --all --parallel=4",


### PR DESCRIPTION
Yarn 2+ does not support prepare lifecycle script, the workaround is to
use postinstall.
https://typicode.github.io/husky/#/?id=install-1