### PR TITLE
fix(serverless-configuration): remove eventBridge.useCloudFormation

### DIFF
--- a/packages/serverless-configuration/src/sharedConfig.ts
+++ b/packages/serverless-configuration/src/sharedConfig.ts
@@ -14,9 +14,6 @@ export const sharedProviderConfig = {
     AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
     NODE_OPTIONS: '--enable-source-maps --stack-trace-limit=1000',
   },
-  eventBridge: {
-    useCloudFormation: true,
-  },
 } as const;
 
 /**


### PR DESCRIPTION
https://www.serverless.com/framework/docs/providers/aws/events/event-bridge#adding-a-dlq-to-an-event-rule

It is now default in Serverless V3